### PR TITLE
Updating SP Ad Groups to Version 3

### DIFF
--- a/ad_api/api/sp/ad_groups.py
+++ b/ad_api/api/sp/ad_groups.py
@@ -1,8 +1,10 @@
-from ad_api.base import Client, sp_endpoint, fill_query_params, ApiResponse
+from ad_api.base import Client, sp_endpoint, fill_query_params, ApiResponse, Utils
+
 
 class AdGroups(Client):
 
     @sp_endpoint('/v2/sp/adGroups', method='POST')
+    @Utils.deprecated
     def create_ad_groups(self, **kwargs) -> ApiResponse:
         r"""
         create_ad_groups(self, \*\*kwargs) -> ApiResponse
@@ -25,6 +27,7 @@ class AdGroups(Client):
         return self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups', method='PUT')
+    @Utils.deprecated
     def edit_ad_groups(self, **kwargs) -> ApiResponse:
         r"""
         edit_ad_group(self, \*\*kwargs) -> ApiResponse
@@ -46,6 +49,7 @@ class AdGroups(Client):
         return self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups', method='GET')
+    @Utils.deprecated
     def list_ad_groups(self, **kwargs) -> ApiResponse:
         r"""
         list_ad_groups(self, \*\*kwargs) -> ApiResponse
@@ -74,6 +78,7 @@ class AdGroups(Client):
         return self._request(kwargs.pop('path'),  params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups/{}', method='GET')
+    @Utils.deprecated
     def get_ad_group(self, adGroupId, **kwargs) -> ApiResponse:
         r"""
 
@@ -91,6 +96,7 @@ class AdGroups(Client):
         return self._request(fill_query_params(kwargs.pop('path'), adGroupId), params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups/{}', method='DELETE')
+    @Utils.deprecated
     def delete_ad_group(self, adGroupId, **kwargs) -> ApiResponse:
         r"""
 
@@ -108,6 +114,7 @@ class AdGroups(Client):
         return self._request(fill_query_params(kwargs.pop('path'), adGroupId), params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups/extended', method='GET')
+    @Utils.deprecated
     def list_ad_groups_extended(self, **kwargs) -> ApiResponse:
         r"""
         list_ad_groups_extended(self, \*\*kwargs) -> ApiResponse
@@ -134,6 +141,7 @@ class AdGroups(Client):
         return self._request(kwargs.pop('path'),  params=kwargs)
 
     @sp_endpoint('/v2/sp/adGroups/extended/{}', method='GET')
+    @Utils.deprecated
     def get_ad_group_extended(self, adGroupId, **kwargs) -> ApiResponse:
         r"""
 

--- a/ad_api/api/sp/ad_groups_v3.py
+++ b/ad_api/api/sp/ad_groups_v3.py
@@ -35,7 +35,7 @@ class AdGroupsV3(Client):
                              headers=headers)
 
     @sp_endpoint("/sp/adGroups", method="PUT")
-    def edit_ad_groups(self, version : int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
+    def edit_ad_groups(self, version: int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
         r"""
         Creates one or more ad groups.
 
@@ -63,9 +63,9 @@ class AdGroupsV3(Client):
                              headers=headers)
 
     @sp_endpoint("/sp/adGroups/delete", method="POST")
-    def delete_ad_groups(self, version, **kwargs) -> ApiResponse:
+    def delete_ad_groups(self, version: int = 3, **kwargs) -> ApiResponse:
         """
-        Deletes Sponsored Products ad groups.
+        Deletes Sponsored Products ad groups by changing it's state to "ARCHIVED".
 
         Request body (required)
             | **adGroupIdFilter** (ObjectIdFilter): The identifier of an existing ad group. [required]
@@ -86,7 +86,7 @@ class AdGroupsV3(Client):
                              headers=headers)
 
     @sp_endpoint("/sp/adGroups/list", method="POST")
-    def list_ad_groups(self, version, **kwargs) -> ApiResponse:
+    def list_ad_groups(self, version: int = 3, **kwargs) -> ApiResponse:
         """
         Lists Sponsored Products campaigns.
 

--- a/ad_api/api/sp/ad_groups_v3.py
+++ b/ad_api/api/sp/ad_groups_v3.py
@@ -1,0 +1,117 @@
+from ad_api.base import Client, sp_endpoint, ApiResponse, Utils
+
+
+class AdGroupsV3(Client):
+    """
+    Version 3 of Sponsored Products API
+    """
+
+    @sp_endpoint("/sp/adGroups", method="POST")
+    def create_ad_groups(self, version: int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
+        r"""
+        Creates one or more ad groups.
+
+        Request body: (required) An array of ad groups
+            | **name** (*string*) : A name for the ad group
+            | **campaignId**: (*string*) : An existing campaign to which the ad group is associated.
+            | **defaultBid**: (*float*) A bid value for use when no bid is specified for keywords in the ad group
+            | **state**: *string* A name for the ad group, Enum: [ enabled, paused, archived ]
+
+        Returns:
+            ApiResponse
+        """
+
+        json_version = "application/vnd.spAdGroup.v" + str(version) + "+json"
+        headers = {
+            "Accept": json_version,
+            "Content-Type": json_version
+        }
+
+        prefer_value = 'return=representation'
+        if prefer:
+            headers.update({"Prefer": prefer_value})
+
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
+
+    @sp_endpoint("/sp/adGroups", method="PUT")
+    def edit_ad_groups(self, version : int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
+        r"""
+        Creates one or more ad groups.
+
+        Request body: (required) An array of ad groups
+            | **name** (*string*) : A name for the ad group
+            | **adGroupId** (*string*) : The identifier of the ad group.
+            | **defaultBid**: (*float*) A bid value for use when no bid is specified for keywords in the ad group
+            | **state**: *string* A name for the ad group, Enum: [ enabled, paused, archived ]
+
+        Returns:
+            ApiResponse
+        """
+
+        json_version = "application/vnd.spAdGroup.v" + str(version) + "+json"
+        headers = {
+            "Accept": json_version,
+            "Content-Type": json_version
+        }
+
+        prefer_value = 'return=representation'
+        if prefer:
+            headers.update({"Prefer": prefer_value})
+
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
+
+    @sp_endpoint("/sp/adGroups/delete", method="POST")
+    def delete_ad_groups(self, version, **kwargs) -> ApiResponse:
+        """
+        Deletes Sponsored Products ad groups.
+
+        Request body (required)
+            | **adGroupIdFilter** (ObjectIdFilter): The identifier of an existing ad group. [required]
+                | **include** (list>str): Entity object identifier. [required] minItems: 0 maxItems: 1000
+
+        Returns
+            ApiResponse
+        """
+
+        json_version = "application/vnd.spAdGroup.v" + str(version) + "+json"
+
+        headers = {
+            "Accept": json_version,
+            "Content-Type": json_version
+        }
+
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
+
+    @sp_endpoint("/sp/adGroups/list", method="POST")
+    def list_ad_groups(self, version, **kwargs) -> ApiResponse:
+        """
+        Lists Sponsored Products campaigns.
+
+        Request Body (optional) : Include the body for specific filtering, or leave empty to get all ad groups.
+            | **state_filter** (State): The returned array is filtered to include only campaigns with state set to one of the values in the specified comma-delimited list. Defaults to `enabled` and `paused`.
+                Note that Campaigns rejected during moderation have state set to `archived`. Available values : enabled, paused, archived[optional]
+            | **nameFilter** (str): The returned array includes only campaigns with the specified name.. [optional]
+                | queryTermMatchType (MatchType > string) Enum : [ BROAD_MATCH, EXACT_MATCH ]
+            | **portfolio_id_filter** (str): The returned array includes only campaigns associated with Portfolio identifiers matching those specified in the comma-delimited string.. [optional]
+            | **campaign_id_filter** (str): The returned array includes only campaigns with identifiers matching those specified in the comma-delimited string.. [optional]
+            | **includeExtendedDataFields** (boolean) Whether to get entity with extended data fields such as creationDate, lastUpdateDate, servingStatus [optional]
+            | **max_results** (int) Number of records to include in the paginated response. Defaults to max page size for given API. Minimum 10 and a Maximum of 100 [optional]
+            | **next_token** (string) Token value allowing to navigate to the next response page. [optional]
+            | **campaignTargetingTypeFilter** (TargetingType > String) Enum : [ AUTO, MANUAL ]
+
+        Returns
+            ApiResponse
+        """
+
+        json_version = "application/vnd.spAdGroup.v" + str(version) + "+json"
+
+        headers = {
+            "Accept": json_version,
+            "Content-Type": json_version
+        }
+
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)

--- a/ad_api/api/sp/campaigns_v3.py
+++ b/ad_api/api/sp/campaigns_v3.py
@@ -14,40 +14,112 @@ class CampaignsV3(Client):
     def create_campaigns(self, version: int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
         r"""
         create_campaigns(body: (dict, str, list)) -> ApiResponse
+
+        Request Body [Required]
+            | **name** (string): [required] The name of the campaign. This name must be unique to the Amazon Advertising account to which the campaign is associated. Maximum length of the string is 128 characters.
+            | **state** (State > string): [required] Enum: [ enabled, paused, archived ]
+            | **portfolio_id** (int) [optional] The identifier of the portfolio to which the campaign is associated.
+            | **budget** (float): [required]
+                | **budgetType** (BudgetType > String) : Enum [DAILY]
+                | **budget** (float) : The budget amount associated with the campaign.
+            | **targetingType** (Targeting > string) : [required] Enum : [AUTO, MANUAL]
+            | **dynamicBidding** ({}) [optional]
+                | **placementBidding** (string) : You can enable controls to adjust your bid based on the placement location. Specify a location where you want to use bid controls.
+                | **strategy** (BiddingStrategy > String) : Enum [LEGACY_FOR_SALES, AUTO_FOR_SALES, MANUAL, RULE_BASED]
+            | **startDate** [optional] (string) : A starting date for the campaign to go live. The format of the date is YYYYMMDD.
+            | **endDate** [optional] (string) : An ending date for the campaign to stop running. The format of the date is YYYYMMDD.
+            | **tags** ({string}) : A list of advertiser-specified custom identifiers for the campaign.
+
+        Returns
+            ApiResponse
+
         """
+
         schema_version = 'application/vnd.spCampaign.v' + str(version) + '+json'
         headers = {"Accept": schema_version, "Content-Type": schema_version}
-        prefer_value = 'return=representation' # return=minimal
+        prefer_value = 'return=representation'  #  return=minimal
         if prefer:
             headers.update({"Prefer": prefer_value})
-        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs, headers=headers)
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
 
     @sp_endpoint('/sp/campaigns', method='PUT')
     def edit_campaigns(self, version: int = 3, prefer: bool = False, **kwargs) -> ApiResponse:
         r"""
         edit_campaigns(body: (dict, str, list)) -> ApiResponse
+
+        Update existing Sponsored Product Campaigns.
+
+        Request Body [Required]
+            | **name** (string): [optional] The name of the campaign. This name must be unique to the Amazon Advertising account to which the campaign is associated. Maximum length of the string is 128 characters.
+            | **state** (State > string): [optional] Enum: [ enabled, paused, archived ]
+            | **portfolio_id** (int) [optional] The identifier of the portfolio to which the campaign is associated.
+            | **budget** (float): [required]
+                | **budgetType** (BudgetType > String) : Enum [DAILY]
+                | **budget** (float) : The budget amount associated with the campaign.
+            | **targetingType** (Targeting > string) : [optional] Enum : [AUTO, MANUAL]
+            | **dynamicBidding** ({}) [optional]
+                | **placementBidding** (string) : You can enable controls to adjust your bid based on the placement location. Specify a location where you want to use bid controls.
+                | **strategy** (BiddingStrategy > String) [required] : Enum [LEGACY_FOR_SALES, AUTO_FOR_SALES, MANUAL, RULE_BASED]
+            | **campaignId** (string) : the entity object identifier
+            | **startDate** [optional] (string) : A starting date for the campaign to go live. The format of the date is YYYYMMDD.
+            | **endDate** [optional] (string) : An ending date for the campaign to stop running. The format of the date is YYYYMMDD.
+            | **tags** ({string}) : A list of advertiser-specified custom identifiers for the campaign.
+
+        Returns
+            ApiResponse
         """
+
         schema_version = 'application/vnd.spCampaign.v' + str(version) + '+json'
         headers = {"Accept": schema_version, "Content-Type": schema_version}
-        prefer_value = 'return=representation' # return=minimal
+        prefer_value = 'return=representation'  #  return=minimal
         if prefer:
             headers.update({"Prefer": prefer_value})
-        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs, headers=headers)
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
 
     @sp_endpoint('/sp/campaigns/list', method='POST')
     def list_campaigns(self, version: int = 3, **kwargs) -> ApiResponse:
         r"""
         list_campaigns(body: (dict, str, list)) -> ApiResponse
+
+        Request Body (optional) : Include the body for specific filtering, or leave empty to get all campaigns.
+            | **state_filter** (State): The returned array is filtered to include only campaigns with state set to one of the values in the specified comma-delimited list. Defaults to `enabled` and `paused`.
+                Note that Campaigns rejected during moderation have state set to `archived`. Available values : enabled, paused, archived[optional]
+            | **nameFilter** (str): The returned array includes only campaigns with the specified name.. [optional]
+                | queryTermMatchType (MatchType > string) Enum : [ BROAD_MATCH, EXACT_MATCH ]
+            | **portfolio_id_filter** (str): The returned array includes only campaigns associated with Portfolio identifiers matching those specified in the comma-delimited string.. [optional]
+            | **campaign_id_filter** (str): The returned array includes only campaigns with identifiers matching those specified in the comma-delimited string.. [optional]
+            | **ad_format_filter** (AdFormat): The returned array includes only campaigns with ad format matching those specified in the comma-delimited adFormats. Returns all campaigns if not specified. Available values : productCollection, video[optional]
+            | **max_results** (int) Number of records to include in the paginated response. Defaults to max page size for given API. Minimum 10 and a Maximum of 100 [optional]
+            | **next_token** (string) Token value allowing to navigate to the next response page. [optional]
+            | includeExtendedDataFields (boolean) Setting to true will slow down performance because the API needs to retrieve extra information for each campaign. [optional]
+
+        Returns
+            ApiResponse
+
         """
         schema_version = 'application/vnd.spCampaign.v' + str(version) + '+json'
         headers = {"Accept": schema_version, "Content-Type": schema_version}
-        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs, headers=headers)
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)
 
     @sp_endpoint('/sp/campaigns/delete', method='POST')
     def delete_campaigns(self, version: int = 3, **kwargs) -> ApiResponse:
         r"""
         delete_campaigns(body: (dict, str, list)) -> ApiResponse
+
+        Deletes Sponsored Products campaigns.
+
+        Request body (required)
+            | **campaignIdFilter** (ObjectIdFilter): The identifier of an existing campaign. [required]
+                | **include** (list>str): Entity object identifier. [required] minItems: 0 maxItems: 1000
+
+        Returns
+            ApiResponse
+
         """
         schema_version = 'application/vnd.spCampaign.v' + str(version) + '+json'
         headers = {"Accept": schema_version, "Content-Type": schema_version}
-        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs, headers=headers)
+        return self._request(kwargs.pop('path'), data=Utils.convert_body(kwargs.pop('body'), False), params=kwargs,
+                             headers=headers)

--- a/docs/sp/ad_groups.rst
+++ b/docs/sp/ad_groups.rst
@@ -1,6 +1,13 @@
 Ad Groups
 =========
 
+.. deprecated:: 4.0.2
+
+.. warning::
+
+    There is a new version 3 of Sponsored Product API, please check the `migration guide`_.
+
+
 .. autoclass:: ad_api.api.sp.AdGroups
     :members:
 

--- a/docs/sp/ad_groups_v3.rst
+++ b/docs/sp/ad_groups_v3.rst
@@ -1,0 +1,16 @@
+Ad Groups
+=========
+
+.. autoclass:: ad_api.api.sp.AdGroupsV3
+
+    .. warning::
+
+        This replaces the version 2 of Ad Groups
+
+    .. autofunction:: ad_api.api.sp.AdGroupsV3.create_campaigns
+
+    .. autofunction:: ad_api.api.sp.AdGroupsV3.edit_campaigns
+
+    .. autofunction:: ad_api.api.sp.AdGroupsV3.list_campaigns
+
+    .. autofunction:: ad_api.api.sp.AdGroupsV3.delete_campaigns

--- a/docs/sp_v3.rst
+++ b/docs/sp_v3.rst
@@ -13,6 +13,7 @@ This specification is available for download from the `Advertising API developer
     :maxdepth: 1
 
     sp/campaignsv3
+    sp/ad_groups_v3
     sp/budget_rules
     sp/campaign_optimization_rules
     sp/ranked_keywords_recommendations


### PR DESCRIPTION
Updating the SP Ad Groups to Version 3 by adding the ad_groups_v3 file.
New Endpoints :
create_ad_groups()
edit_ad_groups()
delete_ad_groups()
list_ad_groups()

Also adding the changes to the docs files.