### PR TITLE
Add support for creating client using access_token only

### DIFF
--- a/ad_api/base/client.py
+++ b/ad_api/base/client.py
@@ -33,7 +33,8 @@ class Client(BaseClient):
             proxies=None,
             verify=True,
             timeout=None,
-            debug=False
+            debug=False,
+            access_token=None,
     ):
 
         self.credentials = CredentialProvider(account, credentials).credentials
@@ -43,6 +44,7 @@ class Client(BaseClient):
             verify=verify,
             timeout=timeout,
         )
+        self._access_token = access_token
         self.endpoint = marketplace.endpoint
         self.debug = debug
         self.timeout = timeout
@@ -61,7 +63,7 @@ class Client(BaseClient):
 
     @property
     def auth(self) -> AccessTokenResponse:
-        return self._auth.get_auth()
+        return self._auth.get_auth() if self._access_token is None else AccessTokenResponse(access_token=self._access_token)
 
     @staticmethod
     def _download(self, params: dict = None, headers=None) -> ApiResponse:


### PR DESCRIPTION
this commit introduces a more secure approach to client creation by enabling the generation of clients using only access_tokens (without client secret and long time refresh_token)