### PR TITLE
Utilizing a more secure method to verify invalidated keys is advisable.

### DIFF
--- a/ad_api/auth/access_token_client.py
+++ b/ad_api/auth/access_token_client.py
@@ -52,9 +52,8 @@ class AccessTokenClient(BaseClient):
         """
 
         cache_key = self._get_cache_key()
-        try:
-            access_token = cache[cache_key]
-        except KeyError:
+        access_token = cache.get(cache_key)
+        if access_token is None:
             request_url = self.scheme + self.host + self.path
             access_token = self._request(request_url, self.data, self.headers)
             cache[cache_key] = access_token


### PR DESCRIPTION
I corrected an error, and during processing the previous exception, another exception occurred. This has been causing the application to crash